### PR TITLE
Fix missing libstdc++.so.6

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -37,7 +37,7 @@
           ];
         in
         {
-          devShells.default = with pkgs; mkShellNoCC {
+          devShells.default = with pkgs; mkShell {
             packages = [
               nil
               nixpkgs-fmt

--- a/nix/rust-esp.nix
+++ b/nix/rust-esp.nix
@@ -2,6 +2,8 @@
 , stdenv
 , fetchurl
 , zlib
+, autoPatchelfHook
+, pkgs
 }:
 let
   platform = {
@@ -16,6 +18,12 @@ in
 stdenv.mkDerivation rec {
   pname = "rust-esp";
   version = "1.78.0.0";
+
+  nativeBuildInputs = with pkgs; [
+    autoPatchelfHook
+    libgcc
+    stdenv.cc.cc.lib
+  ];
 
   src = fetchurl {
     url = "https://github.com/esp-rs/rust-build/releases/download/v${version}/rust-${version}-${platform}.tar.xz";


### PR DESCRIPTION
It fixes the error, but I still have issues with building. What command should I use to build it? When I run `cargo b` I get this error:
```
Unable to find libclang: "the `libclang` shared library at /nix/store/r48jp17ksf8077c1pgvhhzq344z7gjsn-esp-clang-esp-idf-v5.1.3/bin/../lib/libclang.so.15.0.0 could not be opened: libstdc++.so.6: cannot open shared object file: No such file or directo
```
I don't think I fully fixed the missing libstdc++.so.6 issue.